### PR TITLE
feat(single-game-details): load single-game details & frontend updates

### DIFF
--- a/backend/Controllers/GamesController.cs
+++ b/backend/Controllers/GamesController.cs
@@ -7,6 +7,7 @@ using DailyChallenges.Repositories;
 using System.Text.RegularExpressions;
 using System.Globalization;
 using System.Security.Claims;
+using DailyChallenges.Mapping;
 
 namespace DailyChallenges.Controllers
 {
@@ -112,6 +113,14 @@ namespace DailyChallenges.Controllers
         {
             await _games.DeleteAsync(id);
             return NoContent();
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> Get(int id)
+        {
+            var g = await _games.GetByIdAsync(id);
+            if (g == null) return NotFound();
+            return Ok(DtoMapper.ToDto(g));
         }
     }
 }

--- a/backend/Controllers/SubmissionsController.cs
+++ b/backend/Controllers/SubmissionsController.cs
@@ -42,6 +42,13 @@ namespace DailyChallenges.Controllers
             return Ok(dates);
         }
 
+        [HttpGet("game/{gameId}/has-submitted")]
+        public async Task<IActionResult> HasSubmittedForLatest(int gameId)
+        {
+            var has = await _subs.HasUserSubmittedForLatestAsync(gameId, User);
+            return Ok(new { hasSubmittedForLatest = has });
+        }
+
         [HttpGet("game/{gameId}/winner")]
         public async Task<IActionResult> GetWinner(int gameId, [FromQuery] string? scoringDay = null)
         {

--- a/backend/Services/ISubmissionService.cs
+++ b/backend/Services/ISubmissionService.cs
@@ -14,5 +14,6 @@ namespace DailyChallenges.Services
         Task<SubmissionDto?> GetByIdAsync(int id);
         Task<SubmissionDto> UpdateAsync(int id, string? score);
         Task DeleteAsync(int id);
+        Task<bool> HasUserSubmittedForLatestAsync(int gameId, System.Security.Claims.ClaimsPrincipal? user);
     }
 }

--- a/backend/Services/SubmissionService.cs
+++ b/backend/Services/SubmissionService.cs
@@ -80,6 +80,14 @@ namespace DailyChallenges.Services
             return result;
         }
 
+        public async Task<bool> HasUserSubmittedForLatestAsync(int gameId, ClaimsPrincipal? user)
+        {
+            var game = await _games.GetByIdAsync(gameId);
+            var currentDay = GetCurrentScoringDay(game);
+            var userId = user.GetUserId();
+            return await HasUserSubmittedForDayAsync(userId, gameId, currentDay, game);
+        }
+
         private async Task<List<Submission>> GetRecentSubmissionsAsync(int gameId)
         {
             var all = await _subs.GetTopByGameAsync(gameId, 2000);

--- a/frontend/src/pages/GameHighscore.jsx
+++ b/frontend/src/pages/GameHighscore.jsx
@@ -35,11 +35,10 @@ export default function GameHighscore() {
       throw err
     }
 
-    // Fetch submissions only to check whether the current user has submitted today.
+    // Lightweight check for whether the current user has submitted today.
     try {
-      const sres = await api.get(`/submissions/game/${gameId}?page=1&pageSize=200`)
-      const pageResult = sres.data || { items: [], hasSubmittedForLatest: false }
-      setHasSubmittedForLatest(pageResult.hasSubmittedForLatest === true)
+      const sres = await api.get(`/submissions/game/${gameId}/has-submitted`)
+      setHasSubmittedForLatest(sres.data?.hasSubmittedForLatest === true)
     } catch (e) {
       setHasSubmittedForLatest(false)
     }

--- a/frontend/src/pages/GameHighscore.jsx
+++ b/frontend/src/pages/GameHighscore.jsx
@@ -8,6 +8,7 @@ import { useAuth } from '../contexts/AuthContext'
 export default function GameHighscore() {
   const { gameId } = useParams()
   const [game, setGame] = useState(null)
+  const [notFound, setNotFound] = useState(false)
   const [top, setTop] = useState([])
   const { user } = useAuth()
   const [hasSubmittedForLatest, setHasSubmittedForLatest] = useState(false)
@@ -23,9 +24,16 @@ export default function GameHighscore() {
     if (lastFetchKeyRef.current === fetchKey) return
     lastFetchKeyRef.current = fetchKey
 
-    const gres = await api.get('/games')
-    const g = gres.data.find(x => String(x.id) === String(gameId))
-    setGame(g)
+    try {
+      const gres = await api.get(`/games/${gameId}`)
+      setGame(gres.data)
+    } catch (err) {
+      if (err?.response?.status === 404) {
+        setNotFound(true)
+        return
+      }
+      throw err
+    }
 
     // Fetch submissions only to check whether the current user has submitted today.
     try {
@@ -41,6 +49,7 @@ export default function GameHighscore() {
     setTop(data.top || [])
   }
 
+  if (notFound) return <Typography variant="h5" component="h1" role="alert">Game not found</Typography>
   if (!game) return <div>Loading...</div>
 
   const currentScoringDay = game?.currentScoringDay ?? ''

--- a/frontend/src/pages/GameSubmissions.jsx
+++ b/frontend/src/pages/GameSubmissions.jsx
@@ -44,12 +44,16 @@ export default function GameSubmissions() {
   }
 
   const fetchData = async () => {
-    let gameData = null
-    try {
-      const gres = await api.get(`/games/${gameId}`)
-      gameData = gres.data
-      setGame(gameData)
-    } catch (err) {
+    // Fetch game info, available dates and has-submitted in parallel.
+    const gameReq = api.get(`/games/${gameId}`).catch(e => ({ __error: e }))
+    const datesReq = api.get(`/submissions/game/${gameId}/available-dates`).catch(e => ({ __error: e }))
+    const hasSubmittedReq = api.get(`/submissions/game/${gameId}/has-submitted`).catch(e => ({ __error: e }))
+
+    const [gameRes, datesRes, submittedRes] = await Promise.all([gameReq, datesReq, hasSubmittedReq])
+
+    // Handle game response (404 => not found)
+    if (gameRes && gameRes.__error) {
+      const err = gameRes.__error
       if (err?.response?.status === 404) {
         setNotFound(true)
         return
@@ -57,14 +61,11 @@ export default function GameSubmissions() {
       throw err
     }
 
-    // Fetch canonical availableDates from dedicated endpoint
-    let dates = []
-    try {
-      const dr = await api.get(`/submissions/game/${gameId}/available-dates`)
-      dates = dr.data || []
-    } catch (err) {
-      dates = []
-    }
+    const gameData = gameRes?.data
+    setGame(gameData)
+
+    // available dates may fail independently; fall back to empty list
+    const dates = (datesRes && datesRes.__error) ? [] : (datesRes?.data || [])
     setAvailableDates(dates)
 
     // prefer date passed by URL query param, then navigation state
@@ -79,13 +80,9 @@ export default function GameSubmissions() {
     setSelectedDate(initialSelected)
     setPage(1)
 
-    // lightweight check to see if current user has submitted for latest
-    try {
-      const sres = await api.get(`/submissions/game/${gameId}/has-submitted`)
-      setHasSubmittedForLatest(sres.data?.hasSubmittedForLatest === true)
-    } catch (err) {
-      setHasSubmittedForLatest(false)
-    }
+    // use result of has-submitted when available; fall back to false
+    const hasSubmitted = !(submittedRes && submittedRes.__error) && (submittedRes?.data?.hasSubmittedForLatest === true)
+    setHasSubmittedForLatest(hasSubmitted)
 
     if (initialSelected) {
       const dayPage = await fetchSubmissionsPage(1, initialSelected)

--- a/frontend/src/pages/GameSubmissions.jsx
+++ b/frontend/src/pages/GameSubmissions.jsx
@@ -44,9 +44,11 @@ export default function GameSubmissions() {
   }
 
   const fetchData = async () => {
+    let gameData = null
     try {
       const gres = await api.get(`/games/${gameId}`)
-      setGame(gres.data)
+      gameData = gres.data
+      setGame(gameData)
     } catch (err) {
       if (err?.response?.status === 404) {
         setNotFound(true)
@@ -55,8 +57,7 @@ export default function GameSubmissions() {
       throw err
     }
 
-    // Fetch canonical availableDates from dedicated endpoint, then fetch
-    // an unfiltered submissions page to learn submission flags.
+    // Fetch canonical availableDates from dedicated endpoint
     let dates = []
     try {
       const dr = await api.get(`/submissions/game/${gameId}/available-dates`)
@@ -64,19 +65,12 @@ export default function GameSubmissions() {
     } catch (err) {
       dates = []
     }
-    debugger
     setAvailableDates(dates)
-
-    const initial = await fetchSubmissionsPage(1)
-    const initialSubs = initial.items || []
-    setHasSubmittedForLatest(initial.hasSubmittedForLatest === true)
-    if (typeof initial.totalPages === 'number') setHasMore(initial.page < initial.totalPages)
-    else setHasMore(initial.hasMore === true)
 
     // prefer date passed by URL query param, then navigation state
     const preferred = searchParams.get('scoringDay') || location?.state?.selectedDate
     // compute current scoring day (use server-provided when available)
-    const currentDay = g?.currentScoringDay ?? ''
+    const currentDay = gameData?.currentScoringDay ?? ''
     let initialSelected = ''
     if (preferred && dates.includes(preferred)) initialSelected = preferred
     else if (currentDay && dates.includes(currentDay)) initialSelected = currentDay
@@ -84,6 +78,14 @@ export default function GameSubmissions() {
 
     setSelectedDate(initialSelected)
     setPage(1)
+
+    // lightweight check to see if current user has submitted for latest
+    try {
+      const sres = await api.get(`/submissions/game/${gameId}/has-submitted`)
+      setHasSubmittedForLatest(sres.data?.hasSubmittedForLatest === true)
+    } catch (err) {
+      setHasSubmittedForLatest(false)
+    }
 
     if (initialSelected) {
       const dayPage = await fetchSubmissionsPage(1, initialSelected)
@@ -93,6 +95,11 @@ export default function GameSubmissions() {
       else setHasMore(dayPage.hasMore === true)
       // availableDates is provided by the dedicated endpoint; do not override here.
     } else {
+      const initial = await fetchSubmissionsPage(1)
+      const initialSubs = initial.items || []
+
+      if (typeof initial.totalPages === 'number') setHasMore(initial.page < initial.totalPages)
+      else setHasMore(initial.hasMore === true)
       setSubmissions(initialSubs)
     }
   }

--- a/frontend/src/pages/GameSubmissions.jsx
+++ b/frontend/src/pages/GameSubmissions.jsx
@@ -6,9 +6,9 @@ import SubmissionCard from '../components/SubmissionCard'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function GameSubmissions() {
-  const { user } = useAuth()
   const { gameId } = useParams()
   const [game, setGame] = useState(null)
+  const [notFound, setNotFound] = useState(false)
   const [submissions, setSubmissions] = useState([])
   const [page, setPage] = useState(1)
   const [pageSize] = useState(50)
@@ -44,9 +44,16 @@ export default function GameSubmissions() {
   }
 
   const fetchData = async () => {
-    const gres = await api.get('/games')
-    const g = gres.data.find(x => String(x.id) === String(gameId))
-    setGame(g)
+    try {
+      const gres = await api.get(`/games/${gameId}`)
+      setGame(gres.data)
+    } catch (err) {
+      if (err?.response?.status === 404) {
+        setNotFound(true)
+        return
+      }
+      throw err
+    }
 
     // Fetch canonical availableDates from dedicated endpoint, then fetch
     // an unfiltered submissions page to learn submission flags.
@@ -57,6 +64,7 @@ export default function GameSubmissions() {
     } catch (err) {
       dates = []
     }
+    debugger
     setAvailableDates(dates)
 
     const initial = await fetchSubmissionsPage(1)
@@ -122,6 +130,7 @@ export default function GameSubmissions() {
   const currentScoringDay = game?.currentScoringDay ?? ''
   const isViewingLatest = !selectedDate || selectedDate === currentScoringDay
 
+  if (notFound) return <div role="alert">Game not found</div>
   if (!game) return <div>Loading...</div>
 
   return (

--- a/frontend/src/pages/PersonalHighscore.jsx
+++ b/frontend/src/pages/PersonalHighscore.jsx
@@ -8,6 +8,7 @@ import { useAuth } from '../contexts/AuthContext'
 export default function PersonalHighscore() {
   const { gameId } = useParams()
   const [game, setGame] = useState(null)
+  const [notFound, setNotFound] = useState(false)
   const [top, setTop] = useState([])
   const { user, loading } = useAuth()
   const navigate = useNavigate()
@@ -19,14 +20,27 @@ export default function PersonalHighscore() {
       navigate('/login')
       return
     }
-    const gres = await api.get('/games')
-    const g = gres.data.find(x => String(x.id) === String(gameId))
-    setGame(g)
+    try {
+      const gres = await api.get(`/games/${gameId}`)
+      setGame(gres.data)
+    } catch (err) {
+      if (err?.response?.status === 404) {
+        setNotFound(true)
+        return
+      }
+      throw err
+    }
     const res = await api.get(`/games/${gameId}/personal-highscore`)
     const data = res.data || { top: [] }
     setTop(data.top || [])
   }
 
+  if (notFound)
+    return (
+      <Typography variant="h5" role="alert">
+        Game not found
+      </Typography>
+    )
   if (!game) return <div>Loading...</div>
 
   return (

--- a/frontend/src/pages/Submit.jsx
+++ b/frontend/src/pages/Submit.jsx
@@ -42,10 +42,9 @@ export default function Submit() {
     // if logged in, check if user already submitted for this game
     try {
         if (user && user.id) {
-        // Ask backend whether the current user has submitted for latest scoring day
-        const sres = await api.get(`/submissions/game/${gameId}?page=1&pageSize=1`)
-        const pageResult = sres.data || { hasSubmittedForLatest: false }
-        if (pageResult.hasSubmittedForLatest === true) setHasSubmitted(true)
+        // Ask backend whether the current user has submitted for latest scoring day (lightweight)
+        const sres = await api.get(`/submissions/game/${gameId}/has-submitted`)
+        if (sres.data?.hasSubmittedForLatest === true) setHasSubmitted(true)
       }
     } catch (e) {
       // ignore

--- a/frontend/src/pages/Submit.jsx
+++ b/frontend/src/pages/Submit.jsx
@@ -8,6 +8,7 @@ import { useAuth } from '../contexts/AuthContext'
 export default function Submit() {
   const { gameId } = useParams()
   const [game, setGame] = useState(null)
+  const [notFound, setNotFound] = useState(false)
   const [username, setUsername] = useState('')
   const [score, setScore] = useState('')
   const [screenshot, setScreenshot] = useState(null)
@@ -28,9 +29,16 @@ export default function Submit() {
   const [hasSubmitted, setHasSubmitted] = useState(false)
 
   const fetchGame = async () => {
-    const res = await api.get('/games')
-    const g = res.data.find(x => String(x.id) === String(gameId))
-    setGame(g)
+    try {
+      const res = await api.get(`/games/${gameId}`)
+      setGame(res.data)
+    } catch (err) {
+      if (err?.response?.status === 404) {
+        setNotFound(true)
+        return
+      }
+      throw err
+    }
     // if logged in, check if user already submitted for this game
     try {
         if (user && user.id) {
@@ -111,6 +119,13 @@ export default function Submit() {
     return () => window.removeEventListener('paste', handler)
   }, [showSnackbar])   
 
+  if (notFound) {
+    return (
+      <Typography component="h1" role="alert">
+        Game not found
+      </Typography>
+    )
+  }
   if (!game) return <div>Loading...</div>
 
   return (

--- a/tests/e2e/test-utils.ts
+++ b/tests/e2e/test-utils.ts
@@ -103,7 +103,7 @@ export async function createGame(page: Page, providedName?: string) {
   await page.fill('input[type="time"]', '00:00')
 
   const [resp] = await Promise.all([
-    page.waitForResponse(r => r.url().endsWith('/api/games')),
+    page.waitForResponse(r => r.url().endsWith('/api/games') && (r.status() === 200 || r.status() === 201)),
     page.click('button:has-text("Create Game")')
   ])
   expect([200, 201]).toContain(resp.status())
@@ -111,6 +111,9 @@ export async function createGame(page: Page, providedName?: string) {
   // Wait for SPA update after game creation then navigate via UI-only flow.
   await page.waitForTimeout(200)
   await page.goto('/')
+
+  // Ensure the games list has loaded from the API before searching for the created item
+  await page.waitForResponse(r => r.url().endsWith('/api/games') && r.request().method() === 'GET')
 
   // Find the public listing link that contains the game's name and click it.
   // Use a generous timeout to allow the listing to update/render.

--- a/tests/e2e/tests/admin-create-game.spec.ts
+++ b/tests/e2e/tests/admin-create-game.spec.ts
@@ -1,33 +1,13 @@
 import { test, expect } from '@playwright/test'
-import { loginAsAdmin } from '../test-utils'
-import { randomUUID } from 'crypto'
+import { loginAsAdmin, createGame } from '../test-utils'
 
 test('admin can create a new game', async ({ page }) => {
   await loginAsAdmin(page)
 
-  // Go to admin page
-  await page.goto('/admin')
-  await expect(page.locator('text=Manage Games')).toBeVisible()
+  // Use the shared helper which performs a UI-only create and waits for the listing to update
+  const { gameId, gameName } = await createGame(page)
 
-  // Fill create form
-  const uniqueName = `e2e-game-${Date.now()}-${randomUUID()}`
-  await page.fill('label:has-text("Game name") >> xpath=.. >> input', uniqueName).catch(async () => {
-    // fallback: try TextField by role
-    await page.fill('input[aria-label="Game name"]', uniqueName)
-  })
-
-  // Optionally set reset time
-  await page.fill('input[type="time"]', '00:00')
-
-  // Submit form
-  await Promise.all([
-    page.waitForResponse(resp => resp.url().endsWith('/api/games') && (resp.status() === 200 || resp.status() === 201)),
-    page.click('button:has-text("Create Game")')
-  ])
-  await page.waitForTimeout(500) // wait for SPA update after game creation
-
-  // After creation, navigate to games list and assert the new game is visible
+  // Ensure the created game is visible on the public listing
   await page.goto('/')
-  await page.waitForTimeout(500) // wait for SPA update after navigation
-  await expect(page.locator(`text=${uniqueName}`)).toBeVisible()
+  await expect(page.locator(`a:has-text("${gameName}")`).first()).toBeVisible({ timeout: 15000 })
 })

--- a/tests/e2e/tests/pagination-available-dates.spec.ts
+++ b/tests/e2e/tests/pagination-available-dates.spec.ts
@@ -13,6 +13,11 @@ test('pagination, available dates, and page metadata in UI', async ({ page }) =>
     await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(['2026-03-27', '2026-03-26']) })
   })
 
+  // Respond to lightweight has-submitted check used by the UI so the page shows today's scores
+  await page.route(`**/api/submissions/game/${gameId}/has-submitted`, async route => {
+    await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ hasSubmittedForLatest: true }) })
+  })
+
   await page.route(`**/api/submissions/game/${gameId}*`, async route => {
     const req = route.request()
     const url = new URL(req.url())


### PR DESCRIPTION
This PR introduces the single-game details endpoint and frontend updates to fetch a single game's details instead of fetching all games. Includes related service/controller/frontend edits and e2e test stabilizations verified locally (Playwright e2e passed).