### PR TITLE
feat(submissions): skip fetching submissions when user has not submitted

### DIFF
--- a/backend/Controllers/AuthController.cs
+++ b/backend/Controllers/AuthController.cs
@@ -1,11 +1,4 @@
 using Microsoft.AspNetCore.Mvc;
-using DailyChallenges.Data;
-using DailyChallenges.Models;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.IdentityModel.Tokens;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using System.Text;
 
 namespace DailyChallenges.Controllers
 {

--- a/backend/Controllers/GamesController.cs
+++ b/backend/Controllers/GamesController.cs
@@ -1,12 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
-using DailyChallenges.Data;
-using DailyChallenges.Models;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Authorization;
-using DailyChallenges.Repositories;
-using System.Text.RegularExpressions;
-using System.Globalization;
-using System.Security.Claims;
 using DailyChallenges.Mapping;
 
 namespace DailyChallenges.Controllers

--- a/backend/Controllers/SubmissionsController.cs
+++ b/backend/Controllers/SubmissionsController.cs
@@ -1,9 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Globalization;
-using DailyChallenges.Data;
-using DailyChallenges.Models;
-using Microsoft.EntityFrameworkCore;
-using DailyChallenges.Repositories;
 
 namespace DailyChallenges.Controllers
 {

--- a/backend/DTOs/GameDto.cs
+++ b/backend/DTOs/GameDto.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace DailyChallenges.DTOs
 {
     public class GameDto

--- a/backend/DTOs/GameOverviewDto.cs
+++ b/backend/DTOs/GameOverviewDto.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace DailyChallenges.DTOs
 {
     public class OverviewErrorDto

--- a/backend/DTOs/SubmissionDto.cs
+++ b/backend/DTOs/SubmissionDto.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace DailyChallenges.DTOs
 {
     public class SubmissionDto

--- a/backend/DTOs/SubmissionPageDto.cs
+++ b/backend/DTOs/SubmissionPageDto.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace DailyChallenges.DTOs
 {
     public class SubmissionPageDto

--- a/backend/Mapping/DtoMapper.cs
+++ b/backend/Mapping/DtoMapper.cs
@@ -1,6 +1,5 @@
 using DailyChallenges.DTOs;
 using DailyChallenges.Models;
-using System.Linq;
 
 namespace DailyChallenges.Mapping
 {

--- a/backend/Migrations/20260322194021_InitialCreate.cs
+++ b/backend/Migrations/20260322194021_InitialCreate.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/backend/Migrations/20260322205949_AddGameReset.cs
+++ b/backend/Migrations/20260322205949_AddGameReset.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/backend/Migrations/20260329113955_ScoringDayOnSubmission.cs
+++ b/backend/Migrations/20260329113955_ScoringDayOnSubmission.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/backend/Models/Game.cs
+++ b/backend/Models/Game.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace DailyChallenges.Models
 {

--- a/backend/Models/Submission.cs
+++ b/backend/Models/Submission.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 
 namespace DailyChallenges.Models
 {

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -4,9 +4,6 @@ using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
-using System.Threading;
-using DailyChallenges.Services;
-using Microsoft.Extensions.Logging;
 
 var builder = WebApplication.CreateBuilder(args);
 

--- a/backend/Repositories/EfSubmissionRepository.cs
+++ b/backend/Repositories/EfSubmissionRepository.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using DailyChallenges.Data;
 using DailyChallenges.Models;
 using Microsoft.EntityFrameworkCore;

--- a/backend/Repositories/EfSubmissionRepository.cs
+++ b/backend/Repositories/EfSubmissionRepository.cs
@@ -44,7 +44,7 @@ namespace DailyChallenges.Repositories
             return dates;
         }
 
-        public async Task<(List<Submission> Items, int TotalCount, List<DateTime> AvailableDates)> GetByGameFilteredAsync(int gameId, int page, int pageSize, string? search, DateTime? scoringDay)
+        public async Task<(List<Submission> Items, int TotalCount, List<DateTime> AvailableDates)> GetByGameFilteredAsync(int gameId, int page, int pageSize, string? search, DateTime? scoringDay, DateTime? excludeScoringDay = null)
         {
             IQueryable<Submission> q = _db.Submissions.Where(s => s.GameId == gameId);
 
@@ -67,6 +67,12 @@ namespace DailyChallenges.Repositories
                 q = q.Where(s => s.ScoringDay == target);
             }
 
+            if (excludeScoringDay.HasValue)
+            {
+                var ex = excludeScoringDay.Value.Date;
+                q = q.Where(s => s.ScoringDay != ex);
+            }
+
             var total = await q.CountAsync();
 
             if (page < 1) page = 1;
@@ -82,6 +88,16 @@ namespace DailyChallenges.Repositories
                 .ToListAsync();
 
             return (items, total, availableDates);
+        }
+
+        public async Task<Submission?> GetWinnerForGameAndDayAsync(int gameId, DateTime scoringDay)
+        {
+            var target = scoringDay.Date;
+            var numericSubs = _db.Submissions.Where(s => s.GameId == gameId && s.ScoringDay == target && s.ScoreValue.HasValue);
+            if (!await numericSubs.AnyAsync()) return null;
+            var maxScore = await numericSubs.MaxAsync(s => s.ScoreValue!.Value);
+            var winner = await numericSubs.Where(s => s.ScoreValue == maxScore).OrderBy(s => s.CreatedAt).FirstOrDefaultAsync();
+            return winner;
         }
 
         public async Task<Submission?> GetByGameAndUserAsync(int gameId, int userId)

--- a/backend/Repositories/ISubmissionRepository.cs
+++ b/backend/Repositories/ISubmissionRepository.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Threading.Tasks;
 using DailyChallenges.Models;
 
 namespace DailyChallenges.Repositories

--- a/backend/Repositories/ISubmissionRepository.cs
+++ b/backend/Repositories/ISubmissionRepository.cs
@@ -11,7 +11,8 @@ namespace DailyChallenges.Repositories
         Task<List<Submission>> GetByGamePagedAsync(int gameId, int page, int pageSize);
         Task<List<Submission>> GetTopByGameAsync(int gameId, int top);
         Task<Submission?> GetByGameAndUserAsync(int gameId, int userId);
-        Task<(List<Submission> Items, int TotalCount, List<DateTime> AvailableDates)> GetByGameFilteredAsync(int gameId, int page, int pageSize, string? search, DateTime? scoringDay);
+        Task<(List<Submission> Items, int TotalCount, List<DateTime> AvailableDates)> GetByGameFilteredAsync(int gameId, int page, int pageSize, string? search, DateTime? scoringDay, DateTime? excludeScoringDay = null);
+        Task<Submission?> GetWinnerForGameAndDayAsync(int gameId, DateTime scoringDay);
         Task<List<DateTime>> GetAvailableDatesAsync(int gameId);
         Task<Submission> CreateAsync(Submission submission);
         Task<Submission?> GetByIdAsync(int id);

--- a/backend/Services/FileValidator.cs
+++ b/backend/Services/FileValidator.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace DailyChallenges.Services
 {
     public class FileValidator : IFileValidator

--- a/backend/Services/IFileStorage.cs
+++ b/backend/Services/IFileStorage.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace DailyChallenges.Services
 {
     public interface IFileStorage

--- a/backend/Services/IFileValidator.cs
+++ b/backend/Services/IFileValidator.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace DailyChallenges.Services
 {
     public interface IFileValidator

--- a/backend/Services/IGameService.cs
+++ b/backend/Services/IGameService.cs
@@ -1,5 +1,4 @@
 using DailyChallenges.DTOs;
-using Microsoft.AspNetCore.Http;
 
 namespace DailyChallenges.Services
 {

--- a/backend/Services/ISubmissionService.cs
+++ b/backend/Services/ISubmissionService.cs
@@ -1,5 +1,4 @@
 using DailyChallenges.DTOs;
-using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
 
 namespace DailyChallenges.Services

--- a/backend/Services/LocalFileStorage.cs
+++ b/backend/Services/LocalFileStorage.cs
@@ -1,5 +1,3 @@
-using Microsoft.AspNetCore.Http;
-
 namespace DailyChallenges.Services
 {
     // Simple implementation that reads the file into memory and returns bytes.

--- a/backend/Services/SubmissionService.cs
+++ b/backend/Services/SubmissionService.cs
@@ -2,10 +2,7 @@
 using DailyChallenges.Mapping;
 using DailyChallenges.Models;
 using DailyChallenges.Repositories;
-using Microsoft.AspNetCore.Http;
 using System.Security.Claims;
-using System;
-using System.Linq;
 
 namespace DailyChallenges.Services
 {

--- a/backend/Services/SubmissionService.cs
+++ b/backend/Services/SubmissionService.cs
@@ -32,34 +32,26 @@ namespace DailyChallenges.Services
             var userId = user.GetUserId();
             var hasSubmittedForLatest = await HasUserSubmittedForDayAsync(userId, gameId, currentDay, game);
 
-            // Fetch all matching submissions (use a very large page size so repository returns the full set)
-            var fetchPageSize = int.MaxValue / 4;
-            var (allItems, totalCount, _) = await _subs.GetByGameFilteredAsync(gameId, 1, fetchPageSize, null, scoringDay);
-
-            // If caller hasn't submitted today and caller didn't request a specific scoringDay, hide current-day submissions
-            var filteredAll = scoringDay.HasValue ? allItems : FilterSubmissionsForVisibility(allItems, hasSubmittedForLatest, game, currentDay);
-
-            // Use persisted ScoringDay for each submission and determine winners per day using ScoreValue (numeric only)
-            var scored = filteredAll.Select(s => new { Submission = s, Day = s.ScoringDay.Date }).ToList();
-
-            var winnersByDay = new Dictionary<DateTime, Submission>();
-            foreach (var group in scored.GroupBy(x => x.Day))
+            // Determine whether to exclude the current scoring day at the DB level
+            DateTime? excludeScoringDay = null;
+            if (!scoringDay.HasValue && !hasSubmittedForLatest)
             {
-                var numericSubs = group.Where(x => x.Submission.ScoreValue.HasValue).ToList();
-                if (!numericSubs.Any()) continue;
-                var maxScore = numericSubs.Max(x => x.Submission.ScoreValue!.Value);
-                var candidates = numericSubs.Where(x => x.Submission.ScoreValue == maxScore).Select(x => x.Submission).ToList();
-                var winner = candidates.OrderBy(s => s.CreatedAt).First();
-                winnersByDay[group.Key] = winner;
+                excludeScoringDay = currentDay;
             }
 
-            // Apply pagination on filteredAll (ordered by CreatedAt desc)
-            var ordered = filteredAll.OrderByDescending(s => s.CreatedAt).ToList();
-            if (page < 1) page = 1;
-            var skip = (page - 1) * pageSize;
-            var pageSubmissions = ordered.Skip(skip).Take(pageSize).ToList();
+            // Fetch a single page of submissions (repository will apply excludeScoringDay if provided)
+            var (pageItems, totalCount, _) = await _subs.GetByGameFilteredAsync(gameId, page, pageSize, null, scoringDay, excludeScoringDay);
 
-            var mapped = pageSubmissions.Select(s =>
+            // Compute winners only for scoring days present in the returned page by querying the repository per-day
+            var daysInPage = pageItems.Select(s => s.ScoringDay.Date).Distinct().ToList();
+            var winnersByDay = new Dictionary<DateTime, Submission>();
+            foreach (var day in daysInPage)
+            {
+                var winner = await _subs.GetWinnerForGameAndDayAsync(gameId, day);
+                if (winner != null) winnersByDay[day] = winner;
+            }
+
+            var mapped = pageItems.Select(s =>
             {
                 var dto = DtoMapper.ToDto(s);
                 dto.ScoringDay = s.ScoringDay.Date.ToString("yyyy-MM-dd");
@@ -70,8 +62,8 @@ namespace DailyChallenges.Services
 
             result.Items = mapped;
             result.HasSubmittedForLatest = hasSubmittedForLatest;
-            result.TotalCount = filteredAll.Count;
-            result.TotalPages = (int)Math.Ceiling(filteredAll.Count / (double)pageSize);
+            result.TotalCount = totalCount;
+            result.TotalPages = (int)Math.Ceiling(totalCount / (double)pageSize);
             result.HasMore = page < result.TotalPages;
 
             return result;

--- a/frontend/src/pages/GameSubmissions.jsx
+++ b/frontend/src/pages/GameSubmissions.jsx
@@ -70,7 +70,8 @@ export default function GameSubmissions() {
       setSelectedDate(initialSelected)
       setPage(1)
 
-      setHasSubmittedForLatest(!!overview.hasSubmittedForLatest)
+      const userHasSubmitted = !!overview.hasSubmittedForLatest
+      setHasSubmittedForLatest(userHasSubmitted)
 
       if (initialSelected) {
         const dayPage = await fetchSubmissionsPage(1, initialSelected)
@@ -79,11 +80,18 @@ export default function GameSubmissions() {
         if (typeof dayPage.totalPages === 'number') setHasMore(dayPage.page < dayPage.totalPages)
         else setHasMore(dayPage.hasMore === true)
       } else {
-        const initial = await fetchSubmissionsPage(1)
-        const initialSubs = initial.items || []
-        if (typeof initial.totalPages === 'number') setHasMore(initial.page < initial.totalPages)
-        else setHasMore(initial.hasMore === true)
-        setSubmissions(initialSubs)
+        // If the user has not submitted for the latest scoring day and has not selected a day,
+        // skip fetching the submissions list to avoid loading today's hidden submissions.
+        if (!userHasSubmitted) {
+          setSubmissions([])
+          setHasMore(false)
+        } else {
+          const initial = await fetchSubmissionsPage(1)
+          const initialSubs = initial.items || []
+          if (typeof initial.totalPages === 'number') setHasMore(initial.page < initial.totalPages)
+          else setHasMore(initial.hasMore === true)
+          setSubmissions(initialSubs)
+        }
       }
     } catch (err) {
       const e = err
@@ -113,6 +121,12 @@ export default function GameSubmissions() {
     setSelectedDate(value)
     setPage(1)
     setSubmissions([])
+    // If clearing selection (viewing latest) and the user hasn't submitted, skip fetching list
+    if (!value && !hasSubmittedForLatest) {
+      setHasMore(false)
+      return
+    }
+
     const pageResult = await fetchSubmissionsPage(1, value || undefined)
     const subs = pageResult.items || []
     setSubmissions(subs)
@@ -180,6 +194,7 @@ export default function GameSubmissions() {
               <div className="muted" style={{ marginTop: 8 }}>Submit your score to view the leaderboard for today.</div>
               <div style={{ marginTop: 12 }}>
                 <Button component={Link} to={`/submit/${game.id}${location.search || ''}`} className="btn">Submit Score</Button>
+                <Button sx={{ ml: 2 }} onClick={() => handleDateChange(currentScoringDay)} className="btn">Show today's submissions</Button>
               </div>
             </div>
           ) : (

--- a/ideas.md
+++ b/ideas.md
@@ -6,3 +6,4 @@
 - indicator on player count (how many people have played today)
 - Allow editing of your own score
 - Move scoring-day & timezone handling into a small ScoringService with well-tested semantics.
+- Display time correctly, currently time zone agnostic, so +1 in berlin for example


### PR DESCRIPTION
Adds DB-level exclusion for current scoring day and frontend change to skip fetching submissions when the user has not submitted and no scoringDay is selected.