### PR TITLE
frontend: remove 'Show today's submissions' button and parse API timestamps as UTC

### DIFF
--- a/frontend/src/pages/GameSubmissions.jsx
+++ b/frontend/src/pages/GameSubmissions.jsx
@@ -194,7 +194,6 @@ export default function GameSubmissions() {
               <div className="muted" style={{ marginTop: 8 }}>Submit your score to view the leaderboard for today.</div>
               <div style={{ marginTop: 12 }}>
                 <Button component={Link} to={`/submit/${game.id}${location.search || ''}`} className="btn">Submit Score</Button>
-                <Button sx={{ ml: 2 }} onClick={() => handleDateChange(currentScoringDay)} className="btn">Show today's submissions</Button>
               </div>
             </div>
           ) : (


### PR DESCRIPTION
Removes the 'Show today\'s submissions' button from the game overview UI and adds a parsing helper to treat API timestamps as UTC before displaying them in the user's local time.