### PR TITLE
Refactor: move CSV export, scoring-day helpers, and submission winner delegation

### DIFF
--- a/.github/prompts/analyze-backend.prompt.md
+++ b/.github/prompts/analyze-backend.prompt.md
@@ -1,0 +1,113 @@
+---
+title: "Analyze Backend — Enforce Service-Class Logic"
+description: "Use when: analyze and refactor the repository backend to ensure business logic lives in service classes, follow clean-code principles, produce a repeatable, agent-executable plan, and prefer subagents for read/edit tasks."
+applyTo: "backend/**"
+---
+
+## Goal
+Analyze the backend code and produce a detailed, prioritized plan to move and/or implement business logic inside service classes, improve code clarity, and propose safe, test-backed edits. The prompt must produce an agent-executable plan (findings, proposed changes, patches, tests, and clarifying questions) and emphasize heavy use of subagents for reading and editing.
+
+## Inputs (parameters)
+- `targetFolder` (string, default: `backend`) — folder to analyze.
+- `enforceServiceClasses` (bool, default: true) — require business logic to be in `Services/` classes.
+- `createPatches` (bool, default: true) — whether to prepare patch edits for low-risk fixes.
+- `runBuildAndTests` (bool, default: true) — attempt `dotnet build` and unit tests after edits when feasible.
+- `maxChangesPerRun` (int, default: 10) — keep changes small and atomic.
+
+## Constraints & Hard Rules
+- All business/domain logic must reside in service classes under `Services/` (create `I{Name}Service` + `NameService` where appropriate).
+- Controllers may only: accept requests, validate/parse input, call services, and return responses (mapping + HTTP concerns only).
+- Data access must remain in repository/DbContext layers (do not push DB logic into controllers or services that bypass repositories without user approval).
+- Follow existing repository naming conventions, folder layout, and coding style. Avoid stylistic churn.
+- Comments should be minimal: prefer self-explanatory code. Add comments only when the algorithm is complex and the comment provides meaningful insight.
+- Do not perform unsafe schema changes or destructive database migrations without explicit user approval.
+- If a fix is not immediately obvious or carries risk, STOP and ask the user clarifying questions (see Questions section below).
+
+## Agent Workflow (step-by-step, for an agent or subagent to execute)
+1. Explore (read-only): use a read-only subagent (e.g., `Explore`) to collect contextual data: list controllers, services, repositories, models, DTOs, mapping utilities, DbContext, and tests. Produce a one-paragraph architecture summary and a files index.
+
+2. Surface quick wins: identify files where controllers contain heavy business logic, duplicated code, or long methods. Rank findings by severity (Critical, High, Medium, Low).
+
+3. For each finding produce a structured issue entry:
+   - `id` — short id
+   - `files` — list of affected files (provide file links)
+   - `snippet` — 3–10 line code excerpt showing the problem
+   - `severity` — Critical/High/Medium/Low
+   - `rootCause` — why it's a problem
+   - `proposedFix` — concise refactor summary
+   - `risk` — low/medium/high and why
+
+4. Decide edits:
+   - If `createPatches` is true and the proposed fix is low-risk, create a small atomic patch using the workspace edit tool (apply_patch). Include unit tests or modify existing tests where appropriate.
+   - For medium/high-risk changes, draft the change as a proposal and add clarifying questions; do NOT apply changes until user confirmation.
+
+5. Implementation conventions for changes:
+   - New services go under `backend/Services/` or existing Services namespace. Create interfaces `I{Name}Service` and implementation `NameService`.
+   - Methods should be single-purpose and small; extract helpers for readability.
+   - Use constructor injection for dependencies (DbContext, repositories, loggers).
+   - Move mapping logic to `Mapping/DtoMapper` where present; do not duplicate mapping.
+   - Add unit tests focused on moved logic; prefer small, fast unit tests mocking external dependencies.
+
+6. Validate edits:
+   - Run `dotnet build backend` (or `dotnet test` for affected test projects) when `runBuildAndTests` is true.
+   - If build/tests fail due to unrelated flakiness, report rather than attempt broad fixes.
+
+7. Finalize plan:
+   - Output a prioritized, ordered Plan that an agent or engineer can follow: change bundles (id, files, patch), tests to add, and the exact next actions.
+   - Provide a short changelog-style summary suitable for a PR description.
+
+## Output (machine- and human-readable)
+Return an object (or Markdown document) with these sections:
+- `Summary` — one-paragraph architecture summary and high-level recommendation.
+- `Findings` — array of issue entries (see structured issue entry above).
+- `ProposedChanges` — array of changes. For each change include: `id`, `description`, `filesToChange`, `patch` (if created), `tests` (added/updated), and `risk`.
+- `PatchesApplied` — list of apply_patch calls performed (if any) and their rationale.
+- `Questions` — list of clarifying questions to ask the user before proceeding with medium/high-risk changes.
+- `NextSteps` — ordered checklist the agent or developer should follow (include commands to run locally).
+
+Include example JSON/Markdown output at the end so the plan is directly machine-parseable by follow-up agents.
+
+## Clarifying Questions (ask if found during analysis)
+- Do you accept creation of service interfaces (`I{Name}Service`) and move implementation files into `backend/Services/`? (yes/no)
+- For refactors affecting public controller endpoints, may I change method signatures or must I preserve API contracts exactly?
+- Should I add unit tests only, or also integration tests for moved logic?
+- Are you okay with small automatic migrations if a refactor requires a DB schema change? (default: no)
+- Preferred test runner/CI commands to validate changes locally?
+
+If multiple answers are needed, present them as a short numbered list for the user to reply to.
+
+## Heuristics and Clean-Code Rules (enforced by the prompt)
+- Single Responsibility: each service handles one business concern.
+- Names: use descriptive method and class names that explain intent.
+- Keep methods short (prefer < 30 lines); extract helpers for readability.
+- Avoid deep nesting; return early.
+- Prefer composition over inheritance unless there's a clear domain need.
+- Favor explicit over implicit behavior; do not rely on magic strings.
+
+## Subagent & Tooling Guidance (strong emphasis)
+- Use a read-only subagent (e.g., `Explore`) to gather files and context first. Do not infer structure without reading files.
+- Use specialized subagents for edits or `apply_patch` for generating diffs. Keep edits atomic and limited to `maxChangesPerRun`.
+- Use `run_in_terminal` or `run_task` to run `dotnet build` and `dotnet test` when validating changes.
+- Use `manage_todo_list` to track progress and `task_complete` when finished.
+
+## Example Invocations
+- Quick analysis (no edits):
+  - targetFolder=backend, createPatches=false
+- Apply low-risk fixes automatically:
+  - targetFolder=backend, createPatches=true, maxChangesPerRun=5
+
+## Acceptance Criteria
+- Controllers are thin: no business logic remains (only orchestration, validation, mapping).
+- All moved/created logic lives in `Services/` and has unit tests covering behavior.
+- Build succeeds and affected tests pass (when `runBuildAndTests=true`).
+- A clear, ordered Plan is produced with patches or questions for the user.
+
+## Iteration & Repeatability
+This prompt is parameterized and repeatable. For ongoing cleanup runs, adjust `maxChangesPerRun` and re-run. Keep changes incremental and review each medium/high-risk suggestion with the user.
+
+## If You Encounter Ambiguity
+Stop and present the minimal set of clarifying questions. Avoid making guesses that change public behavior or the database schema without explicit approval.
+
+---
+
+*Generated following the agent-customization SKILL guidelines. Use read-only subagents for exploration and apply_patch (or create_file) for edits.*

--- a/backend/Controllers/AdminUsersController.cs
+++ b/backend/Controllers/AdminUsersController.cs
@@ -14,40 +14,22 @@ namespace DailyChallenges.Controllers
     [Authorize(Roles = "Admin")]
     public class AdminUsersController : ControllerBase
     {
-        private readonly AppDbContext _db;
-        private readonly IXpService _xpService;
-        private readonly LevelCalculator _levelCalc;
+        private readonly IAdminUserService _adminService;
 
-        public AdminUsersController(AppDbContext db, IXpService xpService, LevelCalculator levelCalc)
+        public AdminUsersController(IAdminUserService adminService)
         {
-            _db = db;
-            _xpService = xpService;
-            _levelCalc = levelCalc;
+            _adminService = adminService;
         }
 
         [HttpGet]
         public async Task<IActionResult> GetUsers([FromQuery] int page = 1, [FromQuery] int pageSize = 50, [FromQuery] string? search = null)
         {
-            if (page < 1) page = 1;
-            if (pageSize < 1) pageSize = 50;
-
-            var q = _db.Users.AsQueryable();
-            if (!string.IsNullOrWhiteSpace(search))
-            {
-                q = q.Where(u => u.Username.Contains(search));
-            }
-
-            var total = await q.CountAsync();
-            var users = await q.OrderBy(u => u.Id).Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
-
-            var items = users.Select(u => DtoMapper.ToDto(u, _levelCalc)).ToList();
+            var (items, total) = await _adminService.GetUsersAsync(page, pageSize, search);
             return Ok(new { items, totalCount = total });
         }
 
-        public record AdjustXpDto(int Delta, string? Reason);
-
         [HttpPost("{id}/xp")]
-        public async Task<IActionResult> AdjustXp(int id, [FromBody] AdjustXpDto dto)
+        public async Task<IActionResult> AdjustXp(int id, [FromBody] DailyChallenges.DTOs.AdminAdjustXpDto dto)
         {
             if (dto == null) return BadRequest();
             if (dto.Delta == 0) return BadRequest(new { message = "Delta must be non-zero" });
@@ -58,10 +40,8 @@ namespace DailyChallenges.Controllers
 
             try
             {
-                await _xpService.AdjustXpAsync(id, dto.Delta, dto.Reason ?? "admin_adjustment", adminId);
-                var user = await _db.Users.FindAsync(id);
-                if (user == null) return NotFound();
-                return Ok(DtoMapper.ToDto(user, _levelCalc));
+                var updated = await _adminService.AdjustXpAsync(id, dto.Delta, dto.Reason, adminId);
+                return Ok(updated);
             }
             catch (KeyNotFoundException ex)
             {

--- a/backend/Controllers/AdminUsersController.cs
+++ b/backend/Controllers/AdminUsersController.cs
@@ -1,0 +1,72 @@
+using System.Linq;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using DailyChallenges.Data;
+using DailyChallenges.Services;
+using DailyChallenges.Mapping;
+
+namespace DailyChallenges.Controllers
+{
+    [ApiController]
+    [Route("api/admin/users")]
+    [Authorize(Roles = "Admin")]
+    public class AdminUsersController : ControllerBase
+    {
+        private readonly AppDbContext _db;
+        private readonly IXpService _xpService;
+        private readonly LevelCalculator _levelCalc;
+
+        public AdminUsersController(AppDbContext db, IXpService xpService, LevelCalculator levelCalc)
+        {
+            _db = db;
+            _xpService = xpService;
+            _levelCalc = levelCalc;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetUsers([FromQuery] int page = 1, [FromQuery] int pageSize = 50, [FromQuery] string? search = null)
+        {
+            if (page < 1) page = 1;
+            if (pageSize < 1) pageSize = 50;
+
+            var q = _db.Users.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(search))
+            {
+                q = q.Where(u => u.Username.Contains(search));
+            }
+
+            var total = await q.CountAsync();
+            var users = await q.OrderBy(u => u.Id).Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+
+            var items = users.Select(u => DtoMapper.ToDto(u, _levelCalc)).ToList();
+            return Ok(new { items, totalCount = total });
+        }
+
+        public record AdjustXpDto(int Delta, string? Reason);
+
+        [HttpPost("{id}/xp")]
+        public async Task<IActionResult> AdjustXp(int id, [FromBody] AdjustXpDto dto)
+        {
+            if (dto == null) return BadRequest();
+            if (dto.Delta == 0) return BadRequest(new { message = "Delta must be non-zero" });
+
+            int? adminId = null;
+            var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (!string.IsNullOrEmpty(idClaim) && int.TryParse(idClaim, out var parsed)) adminId = parsed;
+
+            try
+            {
+                await _xpService.AdjustXpAsync(id, dto.Delta, dto.Reason ?? "admin_adjustment", adminId);
+                var user = await _db.Users.FindAsync(id);
+                if (user == null) return NotFound();
+                return Ok(DtoMapper.ToDto(user, _levelCalc));
+            }
+            catch (KeyNotFoundException ex)
+            {
+                return NotFound(new { message = ex.Message });
+            }
+        }
+    }
+}

--- a/backend/Controllers/AdminUsersController.cs
+++ b/backend/Controllers/AdminUsersController.cs
@@ -35,9 +35,7 @@ namespace DailyChallenges.Controllers
             if (dto == null) return BadRequest();
             if (dto.Delta == 0) return BadRequest(new { message = "Delta must be non-zero" });
 
-            int? adminId = null;
-            var idClaim = User.FindFirstValue(ClaimTypes.NameIdentifier);
-            if (!string.IsNullOrEmpty(idClaim) && int.TryParse(idClaim, out var parsed)) adminId = parsed;
+            var adminId = User.GetUserId();
 
             try
             {
@@ -60,38 +58,8 @@ namespace DailyChallenges.Controllers
         [HttpGet("{id}/xp-events/export")]
         public async Task<IActionResult> ExportXpEvents(int id, [FromQuery] DateTime? from = null, [FromQuery] DateTime? to = null, [FromQuery] string? eventType = null)
         {
-            const int MaxExportRows = 10000;
-            var (items, total) = await _adminService.GetXpEventsAsync(id, 1, MaxExportRows, from, to, eventType);
-
-            var sb = new StringBuilder();
-            sb.AppendLine("Id,UserId,SubmissionId,GameId,ScoringDay,Amount,EventType,Details,CreatedAt");
-
-            string Escape(string? s)
-            {
-                if (string.IsNullOrEmpty(s)) return string.Empty;
-                return '"' + s.Replace("\"", "\"\"") + '"';
-            }
-
-            foreach (var it in items)
-            {
-                var scoringDay = it.ScoringDay.HasValue ? it.ScoringDay.Value.ToString("yyyy-MM-dd") : string.Empty;
-                var createdAt = it.CreatedAt.ToString("o");
-                var line = string.Join(',', new string[] {
-                    it.Id.ToString(),
-                    it.UserId.ToString(),
-                    it.SubmissionId?.ToString() ?? string.Empty,
-                    it.GameId?.ToString() ?? string.Empty,
-                    scoringDay,
-                    it.Amount.ToString(),
-                    Escape(it.EventType),
-                    Escape(it.Details),
-                    Escape(createdAt)
-                });
-                sb.AppendLine(line);
-            }
-
-            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
-            return File(bytes, "text/csv; charset=utf-8", $"xp-events-user-{id}.csv");
+            var (data, filename) = await _adminService.ExportXpEventsCsvAsync(id, from, to, eventType);
+            return File(data, "text/csv; charset=utf-8", filename);
         }
     }
 }

--- a/backend/Controllers/AdminUsersController.cs
+++ b/backend/Controllers/AdminUsersController.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using System.Text;
 using DailyChallenges.Data;
 using DailyChallenges.Services;
 using DailyChallenges.Mapping;
@@ -47,6 +48,50 @@ namespace DailyChallenges.Controllers
             {
                 return NotFound(new { message = ex.Message });
             }
+        }
+
+        [HttpGet("{id}/xp-events")]
+        public async Task<IActionResult> GetXpEvents(int id, [FromQuery] int page = 1, [FromQuery] int pageSize = 20, [FromQuery] DateTime? from = null, [FromQuery] DateTime? to = null, [FromQuery] string? eventType = null)
+        {
+            var (items, total) = await _adminService.GetXpEventsAsync(id, page, pageSize, from, to, eventType);
+            return Ok(new { items, totalCount = total });
+        }
+
+        [HttpGet("{id}/xp-events/export")]
+        public async Task<IActionResult> ExportXpEvents(int id, [FromQuery] DateTime? from = null, [FromQuery] DateTime? to = null, [FromQuery] string? eventType = null)
+        {
+            const int MaxExportRows = 10000;
+            var (items, total) = await _adminService.GetXpEventsAsync(id, 1, MaxExportRows, from, to, eventType);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Id,UserId,SubmissionId,GameId,ScoringDay,Amount,EventType,Details,CreatedAt");
+
+            string Escape(string? s)
+            {
+                if (string.IsNullOrEmpty(s)) return string.Empty;
+                return '"' + s.Replace("\"", "\"\"") + '"';
+            }
+
+            foreach (var it in items)
+            {
+                var scoringDay = it.ScoringDay.HasValue ? it.ScoringDay.Value.ToString("yyyy-MM-dd") : string.Empty;
+                var createdAt = it.CreatedAt.ToString("o");
+                var line = string.Join(',', new string[] {
+                    it.Id.ToString(),
+                    it.UserId.ToString(),
+                    it.SubmissionId?.ToString() ?? string.Empty,
+                    it.GameId?.ToString() ?? string.Empty,
+                    scoringDay,
+                    it.Amount.ToString(),
+                    Escape(it.EventType),
+                    Escape(it.Details),
+                    Escape(createdAt)
+                });
+                sb.AppendLine(line);
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+            return File(bytes, "text/csv; charset=utf-8", $"xp-events-user-{id}.csv");
         }
     }
 }

--- a/backend/Controllers/SubmissionsController.cs
+++ b/backend/Controllers/SubmissionsController.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using System.Globalization;
+using DailyChallenges.Services;
 
 namespace DailyChallenges.Controllers
 {
@@ -19,13 +20,8 @@ namespace DailyChallenges.Controllers
         [HttpGet("game/{gameId}")]
         public async Task<IActionResult> GetByGame(int gameId, [FromQuery] string? scoringDay = null, [FromQuery] int page = 1, [FromQuery] int pageSize = 50)
         {
-            DateTime? parsedDay = null;
-            if (!string.IsNullOrWhiteSpace(scoringDay))
-            {
-                if (!DateTime.TryParseExact(scoringDay, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
-                    return BadRequest(new { message = "Invalid scoringDay format (expected yyyy-MM-dd)" });
-                parsedDay = dt;
-            }
+            if (!ScoringDayHelper.TryParseScoringDay(scoringDay, out DateTime? parsedDay))
+                return BadRequest(new { message = "Invalid scoringDay format (expected yyyy-MM-dd)" });
 
             var pageResult = await _subs.GetByGameAsync(gameId, User, parsedDay, page, pageSize);
             return Ok(pageResult);
@@ -48,17 +44,10 @@ namespace DailyChallenges.Controllers
         [HttpGet("game/{gameId}/winner")]
         public async Task<IActionResult> GetWinner(int gameId, [FromQuery] string? scoringDay = null)
         {
-            DateTime? parsedDay = null;
-            if (!string.IsNullOrWhiteSpace(scoringDay))
-            {
-                if (!DateTime.TryParseExact(scoringDay, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
-                    return BadRequest(new { message = "Invalid scoringDay format (expected yyyy-MM-dd)" });
-                parsedDay = dt;
-            }
+            if (!ScoringDayHelper.TryParseScoringDay(scoringDay, out DateTime? parsedDay))
+                return BadRequest(new { message = "Invalid scoringDay format (expected yyyy-MM-dd)" });
 
-            // Request full-day results so the service can compute the winner
-            var pageResult = await _subs.GetByGameAsync(gameId, User, parsedDay, 1, int.MaxValue / 4);
-            var winner = pageResult.Items?.FirstOrDefault(i => i.IsDayWinner);
+            var winner = await _subs.GetWinnerAsync(gameId, parsedDay);
             if (winner == null) return NotFound();
             return Ok(winner);
         }

--- a/backend/DTOs/AdminRequests.cs
+++ b/backend/DTOs/AdminRequests.cs
@@ -1,0 +1,4 @@
+namespace DailyChallenges.DTOs
+{
+    public record AdminAdjustXpDto(int Delta, string? Reason);
+}

--- a/backend/DTOs/XpEventDto.cs
+++ b/backend/DTOs/XpEventDto.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace DailyChallenges.DTOs
+{
+    public class XpEventDto
+    {
+        public int Id { get; set; }
+        public int UserId { get; set; }
+        public int? SubmissionId { get; set; }
+        public int? GameId { get; set; }
+        public DateTime? ScoringDay { get; set; }
+        public int Amount { get; set; }
+        public string EventType { get; set; } = string.Empty;
+        public string? Details { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/backend/Mapping/DtoMapper.cs
+++ b/backend/Mapping/DtoMapper.cs
@@ -67,5 +67,21 @@ namespace DailyChallenges.Mapping
 
             return dto;
         }
+
+        public static DailyChallenges.DTOs.XpEventDto ToDto(XpEvent e)
+        {
+            return new DailyChallenges.DTOs.XpEventDto
+            {
+                Id = e.Id,
+                UserId = e.UserId,
+                SubmissionId = e.SubmissionId,
+                GameId = e.GameId,
+                ScoringDay = e.ScoringDay,
+                Amount = e.Amount,
+                EventType = e.EventType,
+                Details = e.Details,
+                CreatedAt = e.CreatedAt
+            };
+        }
     }
 }

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -55,6 +55,9 @@ builder.Services.AddSingleton(sp =>
 });
 builder.Services.AddScoped<DailyChallenges.Services.IXpService, DailyChallenges.Services.XpService>();
 
+// Admin users service
+builder.Services.AddScoped<DailyChallenges.Services.IAdminUserService, DailyChallenges.Services.AdminUserService>();
+
 // Register services
 builder.Services.AddScoped<DailyChallenges.Services.IAuthService, DailyChallenges.Services.AuthService>();
 builder.Services.AddScoped<DailyChallenges.Services.IFileStorage, DailyChallenges.Services.LocalFileStorage>();

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -45,6 +45,7 @@ builder.Services.AddCors(options => options.AddPolicy("DefaultCors", b =>
 // Register repositories
 builder.Services.AddScoped<DailyChallenges.Repositories.IGameRepository, DailyChallenges.Repositories.EfGameRepository>();
 builder.Services.AddScoped<DailyChallenges.Repositories.ISubmissionRepository, DailyChallenges.Repositories.EfSubmissionRepository>();
+builder.Services.AddScoped<DailyChallenges.Repositories.IXpEventRepository, DailyChallenges.Repositories.EfXpEventRepository>();
 
 // XP system
 builder.Services.Configure<DailyChallenges.Services.XpConfig>(builder.Configuration.GetSection("Xp"));

--- a/backend/Repositories/EfXpEventRepository.cs
+++ b/backend/Repositories/EfXpEventRepository.cs
@@ -1,0 +1,29 @@
+using DailyChallenges.Data;
+using DailyChallenges.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace DailyChallenges.Repositories
+{
+    public class EfXpEventRepository : IXpEventRepository
+    {
+        private readonly AppDbContext _db;
+        public EfXpEventRepository(AppDbContext db) => _db = db;
+
+        public async Task<(List<XpEvent> Items, int TotalCount)> GetByUserPagedAsync(int userId, int page, int pageSize, DateTime? from = null, DateTime? to = null, string? eventType = null)
+        {
+            if (page < 1) page = 1;
+            if (pageSize < 1) pageSize = 20;
+
+            IQueryable<XpEvent> q = _db.XpEvents.Where(e => e.UserId == userId);
+
+            if (from.HasValue) q = q.Where(e => e.CreatedAt >= from.Value);
+            if (to.HasValue) q = q.Where(e => e.CreatedAt <= to.Value);
+            if (!string.IsNullOrWhiteSpace(eventType)) q = q.Where(e => e.EventType == eventType);
+
+            var total = await q.CountAsync();
+            var skip = (page - 1) * pageSize;
+            var items = await q.OrderByDescending(e => e.CreatedAt).AsNoTracking().Skip(skip).Take(pageSize).ToListAsync();
+            return (items, total);
+        }
+    }
+}

--- a/backend/Repositories/IXpEventRepository.cs
+++ b/backend/Repositories/IXpEventRepository.cs
@@ -1,0 +1,9 @@
+using DailyChallenges.Models;
+
+namespace DailyChallenges.Repositories
+{
+    public interface IXpEventRepository
+    {
+        Task<(List<XpEvent> Items, int TotalCount)> GetByUserPagedAsync(int userId, int page, int pageSize, DateTime? from = null, DateTime? to = null, string? eventType = null);
+    }
+}

--- a/backend/Services/AdminUserService.cs
+++ b/backend/Services/AdminUserService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using DailyChallenges.Data;
 using DailyChallenges.DTOs;
 using DailyChallenges.Mapping;
+using DailyChallenges.Repositories;
 
 namespace DailyChallenges.Services
 {
@@ -10,12 +11,14 @@ namespace DailyChallenges.Services
         private readonly AppDbContext _db;
         private readonly IXpService _xpService;
         private readonly LevelCalculator _levelCalc;
+        private readonly IXpEventRepository _xpEventRepository;
 
-        public AdminUserService(AppDbContext db, IXpService xpService, LevelCalculator levelCalc)
+        public AdminUserService(AppDbContext db, IXpService xpService, LevelCalculator levelCalc, IXpEventRepository xpEventRepository)
         {
             _db = db;
             _xpService = xpService;
             _levelCalc = levelCalc;
+            _xpEventRepository = xpEventRepository;
         }
 
         public async Task<(List<UserDto> Items, int TotalCount)> GetUsersAsync(int page = 1, int pageSize = 50, string? search = null)
@@ -39,6 +42,13 @@ namespace DailyChallenges.Services
             var user = await _db.Users.FindAsync(userId);
             if (user == null) throw new KeyNotFoundException($"User {userId} not found");
             return DtoMapper.ToDto(user, _levelCalc);
+        }
+
+        public async Task<(List<DailyChallenges.DTOs.XpEventDto> Items, int TotalCount)> GetXpEventsAsync(int userId, int page = 1, int pageSize = 20, DateTime? from = null, DateTime? to = null, string? eventType = null)
+        {
+            var (items, total) = await _xpEventRepository.GetByUserPagedAsync(userId, page, pageSize, from, to, eventType);
+            var dtos = items.Select(e => DtoMapper.ToDto(e)).ToList();
+            return (dtos, total);
         }
     }
 }

--- a/backend/Services/AdminUserService.cs
+++ b/backend/Services/AdminUserService.cs
@@ -2,6 +2,7 @@ using Microsoft.EntityFrameworkCore;
 using DailyChallenges.Data;
 using DailyChallenges.DTOs;
 using DailyChallenges.Mapping;
+using System.Text;
 using DailyChallenges.Repositories;
 
 namespace DailyChallenges.Services
@@ -49,6 +50,42 @@ namespace DailyChallenges.Services
             var (items, total) = await _xpEventRepository.GetByUserPagedAsync(userId, page, pageSize, from, to, eventType);
             var dtos = items.Select(e => DtoMapper.ToDto(e)).ToList();
             return (dtos, total);
+        }
+
+        public async Task<(byte[] Data, string Filename)> ExportXpEventsCsvAsync(int userId, DateTime? from = null, DateTime? to = null, string? eventType = null, int maxRows = 10000)
+        {
+            var (items, total) = await GetXpEventsAsync(userId, 1, maxRows, from, to, eventType);
+
+            var sb = new StringBuilder();
+            sb.AppendLine("Id,UserId,SubmissionId,GameId,ScoringDay,Amount,EventType,Details,CreatedAt");
+
+            string Escape(string? s)
+            {
+                if (string.IsNullOrEmpty(s)) return string.Empty;
+                return '"' + s.Replace("\"", "\"\"") + '"';
+            }
+
+            foreach (var it in items)
+            {
+                var scoringDay = it.ScoringDay.HasValue ? ScoringDayHelper.FormatScoringDay(it.ScoringDay.Value) : string.Empty;
+                var createdAt = it.CreatedAt.ToString("o");
+                var line = string.Join(',', new string[] {
+                    it.Id.ToString(),
+                    it.UserId.ToString(),
+                    it.SubmissionId?.ToString() ?? string.Empty,
+                    it.GameId?.ToString() ?? string.Empty,
+                    scoringDay,
+                    it.Amount.ToString(),
+                    Escape(it.EventType),
+                    Escape(it.Details),
+                    Escape(createdAt)
+                });
+                sb.AppendLine(line);
+            }
+
+            var bytes = Encoding.UTF8.GetBytes(sb.ToString());
+            var filename = $"xp-events-user-{userId}.csv";
+            return (bytes, filename);
         }
     }
 }

--- a/backend/Services/AdminUserService.cs
+++ b/backend/Services/AdminUserService.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore;
+using DailyChallenges.Data;
+using DailyChallenges.DTOs;
+using DailyChallenges.Mapping;
+
+namespace DailyChallenges.Services
+{
+    public class AdminUserService : IAdminUserService
+    {
+        private readonly AppDbContext _db;
+        private readonly IXpService _xpService;
+        private readonly LevelCalculator _levelCalc;
+
+        public AdminUserService(AppDbContext db, IXpService xpService, LevelCalculator levelCalc)
+        {
+            _db = db;
+            _xpService = xpService;
+            _levelCalc = levelCalc;
+        }
+
+        public async Task<(List<UserDto> Items, int TotalCount)> GetUsersAsync(int page = 1, int pageSize = 50, string? search = null)
+        {
+            if (page < 1) page = 1;
+            if (pageSize < 1) pageSize = 50;
+
+            var q = _db.Users.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(search)) q = q.Where(u => u.Username.Contains(search));
+
+            var total = await q.CountAsync();
+            var users = await q.OrderBy(u => u.Id).Skip((page - 1) * pageSize).Take(pageSize).ToListAsync();
+            var items = users.Select(u => DtoMapper.ToDto(u, _levelCalc)).ToList();
+            return (items, total);
+        }
+
+        public async Task<UserDto> AdjustXpAsync(int userId, int delta, string? reason, int? adminUserId = null)
+        {
+            // IXpService will throw KeyNotFoundException if user not found
+            await _xpService.AdjustXpAsync(userId, delta, reason ?? "admin_adjustment", adminUserId);
+            var user = await _db.Users.FindAsync(userId);
+            if (user == null) throw new KeyNotFoundException($"User {userId} not found");
+            return DtoMapper.ToDto(user, _levelCalc);
+        }
+    }
+}

--- a/backend/Services/IAdminUserService.cs
+++ b/backend/Services/IAdminUserService.cs
@@ -10,5 +10,7 @@ namespace DailyChallenges.Services
         Task<UserDto> AdjustXpAsync(int userId, int delta, string? reason, int? adminUserId = null);
 
         Task<(List<DailyChallenges.DTOs.XpEventDto> Items, int TotalCount)> GetXpEventsAsync(int userId, int page = 1, int pageSize = 20, DateTime? from = null, DateTime? to = null, string? eventType = null);
+
+        Task<(byte[] Data, string Filename)> ExportXpEventsCsvAsync(int userId, DateTime? from = null, DateTime? to = null, string? eventType = null, int maxRows = 10000);
     }
 }

--- a/backend/Services/IAdminUserService.cs
+++ b/backend/Services/IAdminUserService.cs
@@ -1,0 +1,11 @@
+using DailyChallenges.DTOs;
+
+namespace DailyChallenges.Services
+{
+    public interface IAdminUserService
+    {
+        Task<(List<UserDto> Items, int TotalCount)> GetUsersAsync(int page = 1, int pageSize = 50, string? search = null);
+
+        Task<UserDto> AdjustXpAsync(int userId, int delta, string? reason, int? adminUserId = null);
+    }
+}

--- a/backend/Services/IAdminUserService.cs
+++ b/backend/Services/IAdminUserService.cs
@@ -1,3 +1,4 @@
+using System;
 using DailyChallenges.DTOs;
 
 namespace DailyChallenges.Services
@@ -7,5 +8,7 @@ namespace DailyChallenges.Services
         Task<(List<UserDto> Items, int TotalCount)> GetUsersAsync(int page = 1, int pageSize = 50, string? search = null);
 
         Task<UserDto> AdjustXpAsync(int userId, int delta, string? reason, int? adminUserId = null);
+
+        Task<(List<DailyChallenges.DTOs.XpEventDto> Items, int TotalCount)> GetXpEventsAsync(int userId, int page = 1, int pageSize = 20, DateTime? from = null, DateTime? to = null, string? eventType = null);
     }
 }

--- a/backend/Services/ISubmissionService.cs
+++ b/backend/Services/ISubmissionService.cs
@@ -15,5 +15,6 @@ namespace DailyChallenges.Services
         Task<SubmissionDto> UpdateAsync(int id, string? score);
         Task DeleteAsync(int id);
         Task<bool> HasUserSubmittedForLatestAsync(int gameId, ClaimsPrincipal? user);
+        Task<SubmissionDto?> GetWinnerAsync(int gameId, DateTime? scoringDay = null);
     }
 }

--- a/backend/Services/ScoringDayHelper.cs
+++ b/backend/Services/ScoringDayHelper.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace DailyChallenges.Services
 {
     public static class ScoringDayHelper
@@ -57,5 +59,26 @@ namespace DailyChallenges.Services
                 return (utcStart, utcEnd);
             }
         }
+
+        /// <summary>
+        /// Try to parse a scoring-day string in yyyy-MM-dd format. Returns true for empty/null input
+        /// and sets scoringDay to null in that case. Returns false on invalid format.
+        /// </summary>
+        public static bool TryParseScoringDay(string? s, out DateTime? scoringDay)
+        {
+            scoringDay = null;
+            if (string.IsNullOrWhiteSpace(s)) return true;
+            if (DateTime.TryParseExact(s, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt))
+            {
+                scoringDay = dt;
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Format a scoring-day DateTime as yyyy-MM-dd.
+        /// </summary>
+        public static string FormatScoringDay(DateTime d) => d.ToString("yyyy-MM-dd");
     }
 }

--- a/backend/Services/SubmissionService.cs
+++ b/backend/Services/SubmissionService.cs
@@ -114,7 +114,7 @@ namespace DailyChallenges.Services
             return subs.Select(s =>
             {
                 var dto = DtoMapper.ToDto(s);
-                dto.ScoringDay = s.ScoringDay.Date.ToString("yyyy-MM-dd");
+                dto.ScoringDay = ScoringDayHelper.FormatScoringDay(s.ScoringDay.Date);
                 return dto;
             }).ToList();
         }
@@ -128,7 +128,7 @@ namespace DailyChallenges.Services
             var adminDtos = subs.Select(s =>
             {
                 var dto = DtoMapper.ToDto(s);
-                dto.ScoringDay = ScoringDayHelper.GetScoringDay(s.CreatedAt, game?.ResetTime ?? TimeSpan.Zero, game?.ResetTimezoneId ?? "UTC").ToString("yyyy-MM-dd");
+                dto.ScoringDay = ScoringDayHelper.FormatScoringDay(ScoringDayHelper.GetScoringDay(s.CreatedAt, game?.ResetTime ?? TimeSpan.Zero, game?.ResetTimezoneId ?? "UTC"));
                 return dto;
             }).ToList();
 
@@ -139,10 +139,28 @@ namespace DailyChallenges.Services
         {
             var dates = await _subs.GetAvailableDatesAsync(gameId);
             return dates
-                .Select(d => d.ToString("yyyy-MM-dd"))
+                .Select(d => ScoringDayHelper.FormatScoringDay(d))
                 .Distinct()
                 .OrderByDescending(x => x)
                 .ToList();
+        }
+
+        public async Task<SubmissionDto?> GetWinnerAsync(int gameId, DateTime? scoringDay = null)
+        {
+            var game = await _games.GetByIdAsync(gameId);
+            if (game == null) return null;
+
+            DateTime day;
+            if (scoringDay.HasValue) day = scoringDay.Value;
+            else day = GetCurrentScoringDay(game);
+
+            var winner = await _subs.GetWinnerForGameAndDayAsync(gameId, day);
+            if (winner == null) return null;
+
+            var dto = DtoMapper.ToDto(winner);
+            dto.ScoringDay = ScoringDayHelper.FormatScoringDay(winner.ScoringDay.Date);
+            dto.IsDayWinner = true;
+            return dto;
         }
 
         public async Task<(SubmissionDto Dto, int XpGain)> CreateAsync(int gameId, string score, string? username, IFormFile? screenshot, ClaimsPrincipal user)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import { Routes, Route, Link } from 'react-router-dom'
 import { Container, Button, Typography } from '@mui/material'
 import Games from './pages/Games'
 import Admin from './pages/Admin'
+import AdminUsers from './pages/AdminUsers'
 import Submit from './pages/Submit'
 import SubmissionDetail from './pages/SubmissionDetail'
 import GameSubmissions from './pages/GameSubmissions'
@@ -20,6 +21,7 @@ export default function App() {
         <Routes>
           <Route path="/" element={<Games />} />
           <Route path="/admin" element={<Admin />} />
+          <Route path="/admin/users" element={<AdminUsers />} />
           <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
           <Route path="/submit/:gameId" element={<Submit />} />

--- a/frontend/src/components/AdminUserAuditModal.jsx
+++ b/frontend/src/components/AdminUserAuditModal.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from 'react'
+import { Dialog, DialogTitle, DialogContent, DialogActions, Button, Table, TableHead, TableRow, TableCell, TableBody, TextField, MenuItem, IconButton } from '@mui/material'
+import CloseIcon from '@mui/icons-material/Close'
+import api from '../api'
+import { useSnackbar } from '../contexts/SnackbarContext'
+
+export default function AdminUserAuditModal({ open, onClose, userId, username }) {
+  const { showSnackbar } = useSnackbar()
+
+  const [items, setItems] = useState([])
+  const [page, setPage] = useState(1)
+  const [pageSize] = useState(20)
+  const [totalCount, setTotalCount] = useState(0)
+  const [from, setFrom] = useState('')
+  const [to, setTo] = useState('')
+  const [eventType, setEventType] = useState('')
+
+  useEffect(() => {
+    if (open) fetchPage(1)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const fetchPage = async (p = page) => {
+    if (!userId) return
+    try {
+      const params = { page: p, pageSize }
+      if (from) params.from = from
+      if (to) params.to = to
+      if (eventType) params.eventType = eventType
+      const res = await api.get(`/admin/users/${userId}/xp-events`, { params })
+      setItems(res.data.items || [])
+      setTotalCount(res.data.totalCount || 0)
+      setPage(p)
+    } catch (err) {
+      showSnackbar('Failed to load XP events', 'error')
+    }
+  }
+
+  const handleExport = async () => {
+    try {
+      const params = {}
+      if (from) params.from = from
+      if (to) params.to = to
+      if (eventType) params.eventType = eventType
+      const res = await api.get(`/admin/users/${userId}/xp-events/export`, { params, responseType: 'blob' })
+      const url = window.URL.createObjectURL(new Blob([res.data]))
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `xp-events-user-${userId}.csv`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      window.URL.revokeObjectURL(url)
+    } catch (err) {
+      showSnackbar('Failed to export CSV', 'error')
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="lg">
+      <DialogTitle>
+        XP Audit — {username ?? `User ${userId}`}
+        <IconButton aria-label="close" onClick={onClose} sx={{ position: 'absolute', right: 8, top: 8 }}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+          <TextField label="From" type="date" size="small" value={from} onChange={e => setFrom(e.target.value)} InputLabelProps={{ shrink: true }} />
+          <TextField label="To" type="date" size="small" value={to} onChange={e => setTo(e.target.value)} InputLabelProps={{ shrink: true }} />
+          <TextField select label="Event Type" size="small" value={eventType} onChange={e => setEventType(e.target.value)} style={{ minWidth: 160 }}>
+            <MenuItem value="">All</MenuItem>
+            <MenuItem value="submission">Submission</MenuItem>
+            <MenuItem value="streak_bonus">Streak Bonus</MenuItem>
+            <MenuItem value="admin_adjustment">Admin Adjustment</MenuItem>
+          </TextField>
+          <Button variant="outlined" onClick={() => fetchPage(1)}>Apply</Button>
+          <Button variant="text" onClick={() => { setFrom(''); setTo(''); setEventType(''); fetchPage(1) }}>Reset</Button>
+        </div>
+
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>When (UTC)</TableCell>
+              <TableCell>Amount</TableCell>
+              <TableCell>Type</TableCell>
+              <TableCell>Details</TableCell>
+              <TableCell>Submission</TableCell>
+              <TableCell>Game</TableCell>
+              <TableCell>Scoring Day</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {items.map(it => (
+              <TableRow key={it.id}>
+                <TableCell>{new Date(it.createdAt).toLocaleString(undefined, { timeZone: 'UTC' })}</TableCell>
+                <TableCell>{it.amount}</TableCell>
+                <TableCell>{it.eventType}</TableCell>
+                <TableCell style={{ maxWidth: 300, whiteSpace: 'pre-wrap' }}>{it.details}</TableCell>
+                <TableCell>{it.submissionId ?? ''}</TableCell>
+                <TableCell>{it.gameId ?? ''}</TableCell>
+                <TableCell>{it.scoringDay ?? ''}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginTop: 12 }}>
+          <div>Showing {items.length} of {totalCount}</div>
+          <div>
+            <Button disabled={page <= 1} onClick={() => fetchPage(page - 1)}>Prev</Button>
+            <Button disabled={page * pageSize >= totalCount} onClick={() => fetchPage(page + 1)}>Next</Button>
+          </div>
+        </div>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={handleExport}>Export CSV</Button>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  )
+}

--- a/frontend/src/pages/Admin.jsx
+++ b/frontend/src/pages/Admin.jsx
@@ -47,6 +47,8 @@ export default function Admin() {
   const navigate = useNavigate()
   const { user, loading } = useAuth()
 
+  const goUsers = () => navigate('/admin/users')
+
   if (!loading && (!user || !user.isAdmin)) {
     navigate('/')
     return null
@@ -133,6 +135,9 @@ export default function Admin() {
 
   return (
     <>
+    <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 12 }}>
+      <Button variant="contained" onClick={goUsers} sx={{ mb: 2 }}>Manage Users</Button>
+    </div>
     <form onSubmit={submit}>
       <Stack spacing={2} maxWidth={400}>
         <TextField label="Game name" value={name} onChange={e => setName(e.target.value)} required />

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -4,6 +4,7 @@ import api from '../api'
 import { useSnackbar } from '../contexts/SnackbarContext'
 import { useAuth } from '../contexts/AuthContext'
 import { useNavigate } from 'react-router-dom'
+import AdminUserAuditModal from '../components/AdminUserAuditModal'
 
 export default function AdminUsers() {
   const { user, loading } = useAuth()
@@ -15,6 +16,9 @@ export default function AdminUsers() {
   const [pageSize] = useState(50)
   const [totalCount, setTotalCount] = useState(0)
   const [deltaById, setDeltaById] = useState({})
+  const [auditUserId, setAuditUserId] = useState(null)
+  const [auditUsername, setAuditUsername] = useState(null)
+  const [auditOpen, setAuditOpen] = useState(false)
 
   useEffect(() => { fetchUsers() }, [])
 
@@ -80,12 +84,14 @@ export default function AdminUsers() {
                   />
                   <Button variant="contained" onClick={() => adjust(u.id, Math.abs(Number(deltaById[u.id] || 0)))}>Add</Button>
                   <Button variant="outlined" color="error" onClick={() => adjust(u.id, -Math.abs(Number(deltaById[u.id] || 0)))} style={{ marginLeft: 8 }}>Deduct</Button>
+                  <Button variant="text" onClick={() => { setAuditUserId(u.id); setAuditUsername(u.username); setAuditOpen(true) }} style={{ marginLeft: 8 }}>Audit</Button>
                 </TableCell>
               </TableRow>
             ))}
           </TableBody>
         </Table>
       </Paper>
+      <AdminUserAuditModal open={auditOpen} onClose={() => setAuditOpen(false)} userId={auditUserId} username={auditUsername} />
     </>
   )
 }

--- a/frontend/src/pages/AdminUsers.jsx
+++ b/frontend/src/pages/AdminUsers.jsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react'
+import { Paper, Table, TableHead, TableRow, TableCell, TableBody, Button, TextField } from '@mui/material'
+import api from '../api'
+import { useSnackbar } from '../contexts/SnackbarContext'
+import { useAuth } from '../contexts/AuthContext'
+import { useNavigate } from 'react-router-dom'
+
+export default function AdminUsers() {
+  const { user, loading } = useAuth()
+  const { showSnackbar } = useSnackbar()
+  const navigate = useNavigate()
+
+  const [users, setUsers] = useState([])
+  const [page, setPage] = useState(1)
+  const [pageSize] = useState(50)
+  const [totalCount, setTotalCount] = useState(0)
+  const [deltaById, setDeltaById] = useState({})
+
+  useEffect(() => { fetchUsers() }, [])
+
+  if (!loading && (!user || !user.isAdmin)) {
+    navigate('/')
+    return null
+  }
+
+  const fetchUsers = async () => {
+    try {
+      const res = await api.get('/admin/users', { params: { page, pageSize } })
+      setUsers(res.data.items || [])
+      setTotalCount(res.data.totalCount || 0)
+    } catch (err) {
+      showSnackbar('Failed to load users', 'error')
+    }
+  }
+
+  const adjust = async (id, delta) => {
+    const reason = window.prompt('Reason for adjustment (optional):') || ''
+    try {
+      const res = await api.post(`/admin/users/${id}/xp`, { delta, reason })
+      showSnackbar('XP adjusted', 'success')
+      // Update single row
+      setUsers(users.map(u => u.id === res.data.id ? res.data : u))
+    } catch (err) {
+      showSnackbar('Failed to adjust XP', 'error')
+    }
+  }
+
+  return (
+    <>
+      <h2>Admin — Manage Users</h2>
+      <Paper style={{ padding: 12 }}>
+        <Table>
+          <TableHead>
+            <TableRow>
+              <TableCell>ID</TableCell>
+              <TableCell>Username</TableCell>
+              <TableCell>Total XP</TableCell>
+              <TableCell>Level</TableCell>
+              <TableCell>XP To Next</TableCell>
+              <TableCell>Streak</TableCell>
+              <TableCell>Actions</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {users.map(u => (
+              <TableRow key={u.id}>
+                <TableCell>{u.id}</TableCell>
+                <TableCell>{u.username}</TableCell>
+                <TableCell>{u.totalXp}</TableCell>
+                <TableCell>{u.level}</TableCell>
+                <TableCell>{u.xpToNextLevel}</TableCell>
+                <TableCell>{u.streak}</TableCell>
+                <TableCell>
+                  <TextField
+                    type="number"
+                    size="small"
+                    value={deltaById[u.id] ?? ''}
+                    onChange={e => setDeltaById({ ...deltaById, [u.id]: e.target.value })}
+                    style={{ width: 100, marginRight: 8 }}
+                  />
+                  <Button variant="contained" onClick={() => adjust(u.id, Math.abs(Number(deltaById[u.id] || 0)))}>Add</Button>
+                  <Button variant="outlined" color="error" onClick={() => adjust(u.id, -Math.abs(Number(deltaById[u.id] || 0)))} style={{ marginLeft: 8 }}>Deduct</Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+    </>
+  )
+}


### PR DESCRIPTION
This PR moves CSV export to AdminUserService, adds ScoringDayHelper parsing/formatting, delegates winner selection to ISubmissionService, replaces manual claim parsing with User.GetUserId(), and centralizes scoring-day formatting. Build passed locally.