### PR TITLE
Add today-submitters endpoint and HiddenScoresCard submitter UI

### DIFF
--- a/backend/Controllers/SubmissionsController.cs
+++ b/backend/Controllers/SubmissionsController.cs
@@ -41,6 +41,13 @@ namespace DailyChallenges.Controllers
             return Ok(new { hasSubmittedForLatest = has });
         }
 
+        [HttpGet("game/{gameId}/today-submitters")]
+        public async Task<IActionResult> GetTodaySubmitters(int gameId)
+        {
+            var result = await _subs.GetTodaySubmittersAsync(gameId);
+            return Ok(result);
+        }
+
         [HttpGet("game/{gameId}/winner")]
         public async Task<IActionResult> GetWinner(int gameId, [FromQuery] string? scoringDay = null)
         {

--- a/backend/DTOs/TodaySubmittersDto.cs
+++ b/backend/DTOs/TodaySubmittersDto.cs
@@ -1,0 +1,8 @@
+namespace DailyChallenges.DTOs
+{
+    public class TodaySubmittersDto
+    {
+        public int Count { get; set; }
+        public List<string> Usernames { get; set; } = new();
+    }
+}

--- a/backend/Repositories/EfSubmissionRepository.cs
+++ b/backend/Repositories/EfSubmissionRepository.cs
@@ -142,6 +142,16 @@ namespace DailyChallenges.Repositories
                 .FirstOrDefaultAsync();
         }
 
+        public async Task<List<string>> GetUsernamesForDayAsync(int gameId, DateTime scoringDay)
+        {
+            var target = scoringDay.Date;
+            return await _db.Submissions
+                .Where(s => s.GameId == gameId && s.ScoringDay == target)
+                .AsNoTracking()
+                .Select(s => s.Username ?? "Anonymous")
+                .ToListAsync();
+        }
+
         public async Task<Submission> CreateAsync(Submission submission)
         {
             _db.Submissions.Add(submission);

--- a/backend/Repositories/ISubmissionRepository.cs
+++ b/backend/Repositories/ISubmissionRepository.cs
@@ -14,6 +14,7 @@ namespace DailyChallenges.Repositories
         Task<Submission?> GetWinnerForGameAndDayAsync(int gameId, DateTime scoringDay);
         Task<List<Submission>> GetWinnersForGameAndDaysAsync(int gameId, List<DateTime> days);
         Task<List<DateTime>> GetAvailableDatesAsync(int gameId);
+        Task<List<string>> GetUsernamesForDayAsync(int gameId, DateTime scoringDay);
         Task<Submission> CreateAsync(Submission submission);
         Task<Submission?> GetByIdAsync(int id);
         Task<Submission> UpdateAsync(Submission submission);

--- a/backend/Services/ISubmissionService.cs
+++ b/backend/Services/ISubmissionService.cs
@@ -16,5 +16,6 @@ namespace DailyChallenges.Services
         Task DeleteAsync(int id);
         Task<bool> HasUserSubmittedForLatestAsync(int gameId, ClaimsPrincipal? user);
         Task<SubmissionDto?> GetWinnerAsync(int gameId, DateTime? scoringDay = null);
+        Task<TodaySubmittersDto> GetTodaySubmittersAsync(int gameId);
     }
 }

--- a/backend/Services/SubmissionService.cs
+++ b/backend/Services/SubmissionService.cs
@@ -117,6 +117,14 @@ namespace DailyChallenges.Services
             return ScoringDayHelper.GetCurrentScoringDay(game?.ResetTime ?? TimeSpan.Zero, game?.ResetTimezoneId ?? "UTC");
         }
 
+        public async Task<TodaySubmittersDto> GetTodaySubmittersAsync(int gameId)
+        {
+            var game = await _games.GetByIdAsync(gameId);
+            var currentDay = GetCurrentScoringDay(game);
+            var usernames = await _subs.GetUsernamesForDayAsync(gameId, currentDay);
+            return new TodaySubmittersDto { Count = usernames.Count, Usernames = usernames };
+        }
+
 
         private List<Submission> FilterSubmissionsForVisibility(List<Submission> subs, bool hasSubmittedToday, Game? game, DateTime currentDay)
         {

--- a/frontend/src/components/ui/HiddenScoresCard.jsx
+++ b/frontend/src/components/ui/HiddenScoresCard.jsx
@@ -1,12 +1,58 @@
-import React from 'react'
-import { Typography, Card } from '@mui/material'
+import React, { useState, useEffect } from 'react'
+import { Typography, Card, Tooltip, CircularProgress } from '@mui/material'
 import AppButton from './AppButton'
+import api from '../../api'
+
+function formatUsernames(names) {
+  if (names.length === 1) return `${names[0]} has already submitted`
+  if (names.length === 2) return `${names[0]} and ${names[1]} have already submitted`
+  const allButLast = names.slice(0, -1).join(', ')
+  return `${allButLast} and ${names[names.length - 1]} have already submitted`
+}
 
 export default function HiddenScoresCard({ gameId, search = '' }) {
+  const [submitters, setSubmitters] = useState(null)
+
+  useEffect(() => {
+    api.get(`/submissions/game/${gameId}/today-submitters`)
+      .then(res => setSubmitters(res.data))
+      .catch(() => setSubmitters({ count: 0, usernames: [] }))
+  }, [gameId])
+
+  const renderSubmitters = () => {
+    if (submitters === null) {
+      return <CircularProgress size={16} sx={{ mt: 1 }} />
+    }
+    if (submitters.count === 0) {
+      return (
+        <div className="muted" style={{ marginTop: 8 }}>
+          🎯 Be the first to submit your score!
+        </div>
+      )
+    }
+    if (submitters.count <= 3) {
+      return (
+        <div className="muted" style={{ marginTop: 8 }}>
+          {formatUsernames(submitters.usernames)}
+        </div>
+      )
+    }
+    return (
+      <div className="muted" style={{ marginTop: 8 }}>
+        <Tooltip title={submitters.usernames.join(', ')} arrow>
+          <span style={{ cursor: 'default', textDecoration: 'underline dotted' }}>
+            {submitters.count} players have already submitted
+          </span>
+        </Tooltip>
+      </div>
+    )
+  }
+
   return (
     <Card sx={{ p: 3 }}>
       <Typography variant="h6">Today's scores are hidden.</Typography>
       <div className="muted" style={{ marginTop: 8 }}>Submit your score to view the leaderboard for today.</div>
+      {renderSubmitters()}
       <div style={{ marginTop: 12 }}>
         <AppButton to={`/submit/${gameId}${search}`}>Submit Score</AppButton>
       </div>


### PR DESCRIPTION
Adds GET /api/submissions/game/{gameId}/today-submitters returning submitter count and usernames for the current scoring day. Updates HiddenScoresCard to show loading, a be-the-first message when none, inline names for up to 3 submitters, and a hover tooltip for 4+.